### PR TITLE
feat: Add profile contract

### DIFF
--- a/contracts/moda-contracts/src/Profile.sol
+++ b/contracts/moda-contracts/src/Profile.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {IERC165, ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC4906} from "./interfaces/IERC4906.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/interfaces/IERC721Metadata.sol";
+import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
+import {IProfile} from "./interfaces/IProfile.sol";
+
+contract Profile is IProfile, IERC721, IERC721Metadata, IERC4906, ERC165 {
+    string private _name;
+    string private _symbol;
+
+    uint256 public totalSupply = 0;
+
+    mapping(uint256 => address) private _tokenToAccount;
+    mapping(address => uint256) private _accountToToken;
+    mapping(uint256 => string) private _tokenToUri;
+
+    error ProfileAlreadyMinted();
+    error ProfileDoesNotExist();
+    error ProfilesAreSoulBound();
+
+    constructor(string memory name_, string memory symbol_) {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev See {IProfile-mint}.
+     */
+    function mint(string memory uri) external {
+        if (_accountToToken[msg.sender] != 0) revert ProfileAlreadyMinted();
+
+        totalSupply++;
+        _accountToToken[msg.sender] = totalSupply;
+        _tokenToAccount[totalSupply] = msg.sender;
+        _tokenToUri[totalSupply] = uri;
+
+        emit Transfer(address(this), msg.sender, totalSupply);
+    }
+
+    /**
+     * @dev See {IProfile-updateProfile}.
+     */
+    function updateProfile(string memory uri) external {
+        uint256 tokenId = _accountToToken[msg.sender];
+        if (tokenId == 0) revert ProfileDoesNotExist();
+
+        _tokenToUri[tokenId] = uri;
+
+        emit MetadataUpdate(tokenId);
+    }
+
+    /**
+     * @dev See {IProfile-accountUri}.
+     */
+    function accountUri(address account) external view returns (string memory) {
+        return tokenURI(_accountToToken[account]);
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory) {
+        if (_tokenToAccount[tokenId] == address(0)) revert ProfileDoesNotExist();
+
+        return _tokenToUri[tokenId];
+    }
+
+    /**
+     * @dev See {IERC721-ownerOf}.
+     */
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        if (_tokenToAccount[tokenId] == address(0)) revert ProfileDoesNotExist();
+        return _tokenToAccount[tokenId];
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function balanceOf(address account) external view returns (uint256 balance) {
+        if (_accountToToken[account] > 0) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-name}.
+     */
+    function name() public view virtual returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-symbol}.
+     */
+    function symbol() public view virtual returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC721-approve}.
+     */
+    function approve(address, uint256) public virtual {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC721-getApproved}.
+     */
+    function getApproved(uint256) public view virtual returns (address) {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC721-setApprovalForAll}.
+     */
+    function setApprovalForAll(address, bool) public virtual {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC721-isApprovedForAll}.
+     */
+    function isApprovedForAll(address, address) public view virtual returns (bool) {
+        return false;
+    }
+
+    /**
+     * @dev See {IERC721-transferFrom}.
+     */
+    function transferFrom(address, address, uint256) public virtual {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(address, address, uint256) public pure {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(address, address, uint256, bytes memory) public virtual {
+        revert ProfilesAreSoulBound();
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IERC721).interfaceId || interfaceId == type(IERC721Metadata).interfaceId
+            || interfaceId == type(IProfile).interfaceId || interfaceId == type(IERC4906).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/moda-contracts/src/interfaces/IERC4906.sol
+++ b/contracts/moda-contracts/src/interfaces/IERC4906.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import "@openzeppelin/contracts/interfaces/IERC165.sol";
+import "@openzeppelin/contracts/interfaces/IERC721.sol";
+
+/// @title EIP-721 Metadata Update Extension
+interface IERC4906 is IERC165, IERC721 {
+    /// @dev This event emits when the metadata of a token is changed.
+    /// So that the third-party platforms such as NFT market could
+    /// timely update the images and related attributes of the NFT.
+    event MetadataUpdate(uint256 _tokenId);
+
+    /// @dev This event emits when the metadata of a range of tokens is changed.
+    /// So that the third-party platforms such as NFT market could
+    /// timely update the images and related attributes of the NFTs.
+    event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId);
+}

--- a/contracts/moda-contracts/src/interfaces/IProfile.sol
+++ b/contracts/moda-contracts/src/interfaces/IProfile.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+/// @title EIP-721 Metadata Update Extension
+interface IProfile is IERC165 {
+    /// @notice An account can only claim one profile. Duplicates will revert.
+    /// @dev This function allows an account to claim a single token.
+    /// @param uri The token URI containing the metadata of an account's profile. e.g. ipfs://<CID>
+    function mint(string memory uri) external;
+
+    /// @notice The caller can only update their own profile. The profile must exist.
+    /// @param uri The token URI containing the metadata of an account's profile. e.g. ipfs://<CID>
+    function updateProfile(string memory uri) external;
+
+    /// @dev This function returns the token URI of a given account.
+    /// @param account An EOA or a contract address.
+    function accountUri(address account) external view returns (string memory);
+}

--- a/contracts/moda-contracts/test/Profile.t.sol
+++ b/contracts/moda-contracts/test/Profile.t.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {Profile} from "../src/Profile.sol";
+import {IProfile} from "../src/interfaces/IProfile.sol";
+import {IERC4906} from "../src/interfaces/IERC4906.sol";
+import {IERC165, ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/interfaces/IERC721Metadata.sol";
+import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+
+contract ProfileTest is Test {
+    Profile public profile;
+
+    address public artist = address(0x1);
+    address public label = address(0x2);
+
+    string public name = "Profile";
+    string public symbol = "PROF";
+
+    string public firstUri = "ipfs://<CID-1>";
+    string public secondUri = "ipfs://<CID-2>";
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed amount);
+    event MetadataUpdate(uint256 _tokenId);
+
+    function setUp() public {
+        profile = new Profile(name, symbol);
+    }
+
+    // constructor
+
+    function test_constructor() public {
+        assertEq(profile.name(), name);
+        assertEq(profile.symbol(), symbol);
+    }
+
+    // mint
+
+    function test_mint_creates_new_token() public {
+        uint256 tokenId = 1;
+
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.accountUri(artist), firstUri);
+        assertEq(profile.tokenURI(tokenId), firstUri);
+        assertEq(profile.ownerOf(tokenId), artist);
+        assertEq(profile.totalSupply(), tokenId);
+    }
+
+    function test_mint_reverts_for_duplicates() public {
+        profile.mint(firstUri);
+        vm.expectRevert(Profile.ProfileAlreadyMinted.selector);
+        profile.mint(firstUri);
+    }
+
+    function test_mint_emits_event() public {
+        vm.startPrank(artist);
+        vm.expectEmit(true, true, true, false);
+        uint256 tokenId = 1;
+        emit Transfer(address(profile), artist, tokenId);
+        profile.mint(firstUri);
+        vm.stopPrank();
+    }
+
+    function test_mint_increments_total_supply() public {
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.totalSupply(), 1);
+
+        vm.startPrank(label);
+        profile.mint(secondUri);
+        vm.stopPrank();
+
+        assertEq(profile.totalSupply(), 2);
+    }
+
+    // totalSupply
+
+    function test_totalSupply_returns_the_token_count() public {
+        assertEq(profile.totalSupply(), 0);
+
+        profile.mint(firstUri);
+
+        assertEq(profile.totalSupply(), 1);
+    }
+
+    // updateProfile
+
+    function test_updateProfile_sets_new_uri() public {
+        uint256 tokenId = 1;
+
+        vm.startPrank(artist);
+
+        profile.mint(firstUri);
+        assertEq(profile.tokenURI(tokenId), firstUri);
+        assertEq(profile.accountUri(artist), firstUri);
+
+        profile.updateProfile(secondUri);
+        assertEq(profile.tokenURI(tokenId), secondUri);
+        assertEq(profile.accountUri(artist), secondUri);
+
+        vm.stopPrank();
+    }
+
+    function test_updateProfile_reverts_for_nonexisting_profile() public {
+        vm.expectRevert(Profile.ProfileDoesNotExist.selector);
+        profile.updateProfile(firstUri);
+    }
+
+    function test_updateProfile_emits_MetadataUpdate() public {
+        uint256 tokenId = 1;
+        profile.mint(firstUri);
+
+        vm.expectEmit(true, true, true, false);
+        emit MetadataUpdate(tokenId);
+        profile.updateProfile(secondUri);
+    }
+
+    // accountUri
+
+    function test_accountUri() public {
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.accountUri(artist), firstUri);
+    }
+
+    function test_accountUri_reverts_with_nonexistent_profile() public {
+        vm.expectRevert(Profile.ProfileDoesNotExist.selector);
+
+        profile.accountUri(artist);
+    }
+
+    // tokenUri
+
+    function test_tokenUri() public {
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.tokenURI(1), firstUri);
+    }
+
+    function test_tokenUri_reverts_with_nonexistent_token() public {
+        vm.expectRevert(Profile.ProfileDoesNotExist.selector);
+
+        profile.tokenURI(1);
+    }
+
+    // ownerOf
+
+    function test_ownerOf() public {
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.ownerOf(1), artist);
+    }
+
+    function test_ownerOf_reverts_with_nonexistent_token() public {
+        vm.expectRevert(Profile.ProfileDoesNotExist.selector);
+
+        profile.ownerOf(1);
+    }
+
+    // balanceOf
+
+    function test_balanceOf_with_profile() public {
+        vm.startPrank(artist);
+        profile.mint(firstUri);
+        vm.stopPrank();
+
+        assertEq(profile.balanceOf(artist), 1);
+    }
+
+    function test_balanceOf_without_profile() public {
+        assertEq(profile.balanceOf(artist), 0);
+    }
+
+    // name
+
+    function test_name() public {
+        assertEq(profile.name(), name);
+    }
+
+    // symbol
+
+    function test_symbol() public {
+        assertEq(profile.symbol(), symbol);
+    }
+
+    // approve
+
+    function test_approve_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.approve(label, 1);
+    }
+
+    // getApproved
+
+    function test_getApproved_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.getApproved(1);
+    }
+
+    // setApprovalForAll
+
+    function test_setApprovalForAll_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.setApprovalForAll(label, true);
+    }
+
+    // isApprovedForAll
+
+    function test_isApprovedForAll() public {
+        assertFalse(profile.isApprovedForAll(artist, label));
+    }
+
+    // transferFrom
+
+    function test_transferFrom_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.transferFrom(artist, label, 1);
+    }
+
+    // safeTransferFrom
+
+    function test_safeTransferFrom_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.safeTransferFrom(artist, label, 1);
+    }
+
+    // safeTransferFrom with data argument
+
+    function test_safeTransferFrom_with_data_arg_reverts() public {
+        vm.expectRevert(Profile.ProfilesAreSoulBound.selector);
+        profile.safeTransferFrom(artist, label, 1, bytes(""));
+    }
+
+    // supportsInterface
+
+    function test_supports_IProfile() public {
+        assertTrue(profile.supportsInterface(type(IProfile).interfaceId));
+    }
+
+    function test_supports_IERC721() public {
+        assertTrue(profile.supportsInterface(type(IERC721).interfaceId));
+    }
+
+    function test_supports_IERC721Metadata() public {
+        assertTrue(profile.supportsInterface(type(IERC721Metadata).interfaceId));
+    }
+
+    function test_supports_IERC4906() public {
+        assertTrue(profile.supportsInterface(type(IERC4906).interfaceId));
+    }
+
+    function test_supports_ERC165() public {
+        assertTrue(profile.supportsInterface(type(ERC165).interfaceId));
+    }
+
+    function test_supports_IERC165() public {
+        assertTrue(profile.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function test_returns_false_for_unsupported_interfaces() public {
+        assertFalse(profile.supportsInterface(type(IERC2981).interfaceId));
+    }
+}

--- a/words.txt
+++ b/words.txt
@@ -14,3 +14,5 @@ remappings
 unregisters
 blanco
 struct
+IERC
+ipfs


### PR DESCRIPTION
Profile
---

[IERC4906](https://eips.ethereum.org/EIPS/eip-4906) requires that we emit an event when a URI is changed. This gives OpenSea, and any other API the opportunity to update its cache. Seems appropriate for a profile API. OpenSea will also automatically update now...

<img width="1070" alt="Screenshot 2023-11-14 at 2 56 40 PM" src="https://github.com/modadao/moda-protocol/assets/2101499/3d9827db-73f7-44a0-8bbb-636f81a1e38f">
