### PR TITLE
chore: Add script to print out contract sizes

### DIFF
--- a/moda-contracts/package.json
+++ b/moda-contracts/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "forge clean && forge build && forge test --ffi",
-    "coverage": "forge coverage --report lcov --ffi && genhtml lcov.info --branch-coverage --output-dir coverage "
+    "coverage": "forge coverage --report lcov --ffi && genhtml lcov.info --branch-coverage --output-dir coverage ",
+    "size": "forge build --sizes"
   },
   "keywords": [],
   "author": "",

--- a/words.txt
+++ b/words.txt
@@ -23,4 +23,6 @@ chainid
 xsplit
 web3
 unregistration
+genhtml
+lcov
 


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [x] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description
- Run `pnpm size` to print out the sizes of all compiled contracts not including tests 